### PR TITLE
Notes for text pilots and brief instructions Airbus and Boeing directs

### DIFF
--- a/alias.txt
+++ b/alias.txt
@@ -175,8 +175,8 @@
 
 --- HELP ---
 .tipptxt Tipp when you fly as Text-Pilot, fly first all written manoeuvres before you write back the instruction thanks
-.dctfms How to fly a Direct: 1)go to LEGS page 2)TYPE THE  DIRECT IN EXAMPLE DT442 3) Press LLSK1 on LEGS first page to paste the waypoint to the first position. 4)press EXEC
-.dctmcdu How to fly a direct 1)select "DIR"-Key on the MCDU 2)Enter Direct for Example DT442 3) Press DIR TO INSERT*
+.dctfms How to fly a Direct: 1) Go to LEGS page 2) TYPE THE DIRECT $1 IN 3) Press LLSK1 on LEGS first page to paste the waypoint to the first position. 4)press EXEC
+.dctmcdu How to fly a direct 1) Select "DIR"-Key on the MCDU 2) Enter Direct for $1 3) Press DIR TO INSERT*
 .helpnewbie You seem to be new to VATSIM. First of all: Welcome! It might be tempting to jump straight in and start flying, but I suggest you read through some documentation first in order to prepare yourself for the situations you will encounter on the network. You can find a lot of helpful information at https://my.vatsim.net/learn. For information on German procedures, take a look at https://kb.vatsim-germany.org. If you have any questions, feel free to ask them at https://forum.vatsim.net or one of the Discord servers at https://community.vatsim.net/servers.
 .helptext You are indicating that you are only able to communicate via text. Please keep in mind that text communications add significantly to ATC's workload, so they might not immediately be able to answer you. If you have access to headphones or speakers, please select at least "Receive only" when filing your flight plan.
 .helppm Please don't send private messages to ATC as they are a lot of work for them, so please use the frequency. If you have a question that doesn't belong on the frequency, please ask them at https://forum.vatsim.net/ or one of the Discord servers at https://community.vatsim.net/servers.

--- a/alias.txt
+++ b/alias.txt
@@ -69,6 +69,8 @@
 .sqc Squawk Charlie.
 .sqs Squawk Standby.
 .id Identified.
+.idT Identified, please remember this standard tip when you fly as Text-Pilot, fly first all written manoeuvres before you write back the instruction thanks
+.ie $radioname identified, expect ILS APP RWY $arrrwy, ATIS information $atiscode($arr) current.
 .c Climb flight level $uc($1).
 .ca Climb altitude $uc($1)ft.
 .cvs Climb via SID flight level $uc($1).
@@ -172,6 +174,9 @@
 .dwake Achtung Wirbelschleppen.
 
 --- HELP ---
+.tipptxt Tipp when you fly as Text-Pilot, fly first all written manoeuvres before you write back the instruction thanks
+.dctfms How to fly a Direct: 1)go to LEGS page 2)TYPE THE  DIRECT IN EXAMPLE DT442 3) Press LLSK1 on LEGS first page to paste the waypoint to the first position. 4)press EXEC
+.dctmcdu How to fly a direct 1)select "DIR"-Key on the MCDU 2)Enter Direct for Example DT442 3) Press DIR TO INSERT*
 .helpnewbie You seem to be new to VATSIM. First of all: Welcome! It might be tempting to jump straight in and start flying, but I suggest you read through some documentation first in order to prepare yourself for the situations you will encounter on the network. You can find a lot of helpful information at https://my.vatsim.net/learn. For information on German procedures, take a look at https://kb.vatsim-germany.org. If you have any questions, feel free to ask them at https://forum.vatsim.net or one of the Discord servers at https://community.vatsim.net/servers.
 .helptext You are indicating that you are only able to communicate via text. Please keep in mind that text communications add significantly to ATC's workload, so they might not immediately be able to answer you. If you have access to headphones or speakers, please select at least "Receive only" when filing your flight plan.
 .helppm Please don't send private messages to ATC as they are a lot of work for them, so please use the frequency. If you have a question that doesn't belong on the frequency, please ask them at https://forum.vatsim.net/ or one of the Discord servers at https://community.vatsim.net/servers.


### PR DESCRIPTION
Hinweise für Textpiloten insbesondere in Approach bereich eingebaut, alle Manöver auszuführen und dann erst zurückzuschreiben um delays zu vermeiden. Einbau simpler schnell Anleitungen Boeing und Airbus zur eingabe von directs.