### PR TITLE
QoL changes

### DIFF
--- a/alias.txt
+++ b/alias.txt
@@ -3,6 +3,7 @@
 .rpos report your position
 .co contact $radioname($1), $freq($1)
 .costby standby for $radioname($1), $freq($1)
+.coa revised airborne frequency is contact $radioname($1) on $freq($1)
 .uni monitor Unicom, 122.800
 .nma you are not in my airspace, switch back to Unicom, 122.800
 .wf wrong frequency, check again with the previous controller
@@ -15,13 +16,15 @@
 .rbc readback correct
 .q QNH $altim($1)
 .wallcoc .wallop $aircraft unable to comply with ATC instructions (CoC B8)
-.wallnoco .wallop $aircraft not in contact with anyone and ignoring contact me messages (CoC B3)
+.wallnoco .wallop $aircraft not in contact with anyone and ignoring contact me messages (CoC B3), first contact me sent at $1
 .wallemer .wallop $aircraft not cancelling their emergency despite having been instructed to do so (CoC B6)
+.wxdep $metar($dep)
+.wxarr $metar($arr)
 
 ;--- DELIVERY ---
 .nofp I have not received a flight plan from you. Please make sure you have actually filed one, have set the correct ICAO codes for the departure and arrival airport, and that the callsign in your flight plan and the one you are connected with are the same. If you have just flown inbound already, please also reconnect to the network to ensure that you appear on the controllers' screens
-.rte The route you have filed is invalid. You can find valid routes for many destinations at https://grd.aero-nav.com
-.newrte The route you have filed is invalid. Please refile with the following route to $arr: $uc($1)
+.rte .msg $aircraft The route you have filed is invalid. You can find valid routes for many destinations at https://grd.aero-nav.com
+.newrte .msg $aircraft The route you have filed is invalid. Please refile with the following route to $arr: $uc($1)
 .tobt please set your TOBT at https://vacdm.vatger.de
 .tsat You can find your current TSAT at https://vacdm.vatger.de
 .clr cleared to $arr, $sid departure, flight planned route, climb to $temp, squawk $squawk
@@ -77,15 +80,13 @@
 .sqstby squawk Standby
 .sqv squawk VFR
 .id identified
-.c climb to flight level $temp
-.ca climb to altitude $temp
-.cvs climb via SID to flight level $temp
-.d descend to flight level $temp
-.da descend to altitude $temp
-.daq descend to altitude $temp, QNH $altim($arr)
-.dvs descend via STAR to flight level $temp
-.dvsa descend via STAR to altitude $temp, QNH $altim($arr)
-.dtr when ready, descend to reach flight level $temp at $uc($2)
+.c climb to $temp
+.cvs climb via SID to $temp
+.d descend to $temp
+.dq descend to $temp, QNH $altim($arr)
+.dvs descend via STAR to $temp
+.dvsq descend via STAR to $temp, QNH $altim($arr)
+.dtr when ready, descend to reach $temp at $uc($2)
 .roc climb at $1 ft per minute
 .rocg climb at $1 ft per minute or greater
 .rocl climb at $1 ft per minute or less
@@ -156,12 +157,12 @@
 .xcl you have crossed the final approach course, turn left immediately and return to the final approach course runway $arrrwy
 .xcr you have crossed the final approach course, turn right immediately and return to the final approach course runway $arrrwy
 .det to avoid traffic deviating from adjacent approach
-.spd fly speed $1 knots
-.spdg fly speed $1 knots or greater
-.spdl fly speed $1 knots or less
-.spdu fly speed $1 knots until $2 miles final
-.spdug fly speed $1 knots or greater until $uc($2) miles final
-.spdul fly speed $1 knots or less until $uc($2) miles final
+.spd maintain speed $1 knots
+.spdg maintain speed $1 knots or greater
+.spdl maintain speed $1 knots or less
+.spdu maintain speed $1 knots until $2 miles final
+.spdug maintain speed $1 knots or greater until $uc($2) miles final
+.spdul maintain speed $1 knots or less until $uc($2) miles final
 .spdm maintain Mach .$1
 .spdmg maintain Mach .$1 or greater
 .spdml maintain Mach .$1 or less
@@ -189,7 +190,7 @@
 .360r make a right 360
 .tc join traffic circuit runway $uc($1)
 .tcr join right traffic circuit runway $uc($1)
-.tfc traffic information, $uc($1), report in sight
+.tfc traffic information, $1, report in sight
 .tfc2 follow mentioned traffic, number 2
 .down join downwind runway $uc($1)
 .downr join right downwind runway $uc($1)
@@ -236,11 +237,11 @@
 .dctg Wind $wind, Piste $arrrwy, frei zum Aufsetzen und Durchstarten
 .dcla Wind $wind, Piste $arrrwy, frei zum Tiefanflug
 .drdy melden Sie abflugbereit
-.dstop halten Sie Position, Startfreigabe aufgehoben, ich wiederhole, Startfreigabe aufgehoben
+.dstop halten Sie Position, Startfreigabe aufgehoben
 .dga starten Sie durch
 .dlu rollen Sie zum Abflugpunkt Piste $deprwy
-.dludep hinter nächster abfliegenden $uc($1), rollen Sie zum Abflugpunkt Piste $deprwy, dahinter
-.dluarr hinter nächster anfliegenden $uc($1), rollen Sie zum Abflugpunkt Piste $deprwy, dahinter
+.dludep hinter nächster abfliegenden $1, rollen Sie zum Abflugpunkt Piste $deprwy, dahinter
+.dluarr hinter nächster anfliegenden $1, rollen Sie zum Abflugpunkt Piste $deprwy, dahinter
 .dhp halten Sie Position
 .dt rollen Sie zum Rollhalt Piste $deprwy über $uc($1)
 .dts rollen Sie zu Parkposition $uc($1) über $uc($2)
@@ -254,22 +255,22 @@
 .dcol Verlassen der Frequenz genehmigt
 
 ;--- HELP ---
-.helpnewbie You seem to be new to VATSIM. First of all: Welcome! It might be tempting to jump straight in and start flying, but we suggest you read through some documentation first in order to prepare yourself for the situations you will encounter on the network. You can find a lot of helpful information at https://my.vatsim.net/learn. For Germany-specific information, take a look at https://kb.vatger.de. If you have any questions, feel free to ask them at https://forum.vatsim.net or one of the Discord servers at https://community.vatsim.net/servers
-.helptext You are indicating that you are only able to communicate via text. Please keep in mind that text communications add significantly to ATC's workload, so they might not immediately be able to answer you. If you have access to headphones or speakers, please select at least "Receive only" when filing your flight plan; if you also have access to a microphone, please select "Voice". While flying with "Text only" or "Receive only", please also start following all instructions prior to writing your readback
-.helppm Please don't send private messages to controllers as they add significantly to ATC's workload; use the frequency instead. If you have a question that doesn't belong on frequency, please ask it at https://forum.vatsim.net/ or one of the Discord servers at https://community.vatsim.net/servers
-.helpcharts You can find free and current IFR charts for German airports at https://chartfox.org; free and current VFR charts for German airports can be found at https://www.vfraip.de/
-.helpsector You can find an accurate map of the current ATC coverage and sector splits at https://vatglasses.uk/
-.helpgg You can find pilot briefings for airports in FIR Langen at https://knowledgebase.vatsim-germany.org/books/airports-langen-fir-edgg
-.helpmm You can find pilot briefings for airports in FIR Munich at https://knowledgebase.vatsim-germany.org/books/airports-munchen-fir-edmm
-.helpww You can find pilot briefings for airports in FIR Bremen at https://knowledgebase.vatsim-germany.org/books/airports-bremen-fir-edww
-.helpxx You can find pilot briefings for uncontrolled airfields throughout Germany at https://knowledgebase.vatsim-germany.org/books/airfields-germany
-.helpkb You can find a lot of helpful information in the VATSIM Germany Knowledgebase (https://kb.vatger.de)
-.helpiata You seem to be logged in with the 2-letter IATA code for your airline. On VATSIM (and in the real world), we use the 3-letter ICAO codes. Please change your callsign accordingly and don't forget that you will have to refile your flight plan with the correct callsign as well. Otherwise, ATC might not recognize your callsign
-.helpequip You have not filed an equipment code (or have filed one that is most likely incorrect). Please keep in mind that filing a correct equipment code helps controllers to quickly see what type of procedures you are able to fly etc. You can learn more about equipment codes at https://www.faa.gov/sites/faa.gov/files/FAA%20FPL%20Quick%20Reference%20Brochure%20%282022-09-15%29.pdf
-.help833 You have been transferred to an 8.33kHz channel. If your simulator and/or aircraft does not support 8.33kHz channel spacing, you have to use ".com1 <frequency>" in your pilot client to tune to the correct frequency. You can learn more about the introduction of 8.33kHz channels to VATSIM at https://vats.im/833
-.helpxc Not all frequencies in use will show in the controller list of your pilot client, especially if a controller is using multiple frequencies. To ensure you can properly communicate with the correct controller, please always switch to the frequency given by ATC during the handoff
-.helpacdm If you are unfamiliar with the ACDM process, you can learn about it at https://knowledgebase.vatsim-germany.org/books/vacdm/page/vacdm-pilot-guide
-.helpfl Hey I corrected your readback to FL0X0, as you said X000ft. Therefore an explanation: FL0X0 and X000ft are not the same! But where is the difference? If you are cleared to climb FL0X0, you should change your altimeter setting to STD during climb (in Germany when passing 5000ft) and level off at FL0X0 on QNH STD. If you are cleared to X000ft, you should climb to X000ft with local QNH. Summary: FL = QNH STD and ALT xxxx ft = local QNH
+.helpnewbie .msg $aircraft You seem to be new to VATSIM. First of all: Welcome! It might be tempting to jump straight in and start flying, but we suggest you read through some documentation first in order to prepare yourself for the situations you will encounter on the network. You can find a lot of helpful information at https://my.vatsim.net/learn. For Germany-specific information, take a look at https://kb.vatger.de. If you have any questions, feel free to ask them at https://forum.vatsim.net or on one of the Discord servers at https://community.vatsim.net/servers
+.helptext .msg $aircraft You are indicating that you are only able to communicate via text. Please keep in mind that text communications add significantly to ATC's workload, so they might not immediately be able to answer you. If you have access to headphones or speakers, please select at least "Receive only" when filing your flight plan; if you also have access to a microphone, please select "Voice". While flying with "Text only" or "Receive only", please also start following all instructions prior to writing your readback
+.helppm .msg $aircraft Please don't send private messages to controllers as they add significantly to ATC's workload; use the frequency instead. If you have a question that doesn't belong on frequency, please ask it at https://forum.vatsim.net/ or one of the Discord servers at https://community.vatsim.net/servers
+.helpcharts .msg $aircraft You can find free and current IFR charts for German airports at https://chartfox.org; free and current VFR charts for German airports can be found at https://www.vfraip.de/
+.helpsector .msg $aircraft You can find an accurate map of the current ATC coverage and sector splits at https://vatglasses.uk/
+.helpgg .msg $aircraft You can find pilot briefings for airports in FIR Langen at https://knowledgebase.vatsim-germany.org/books/airports-langen-fir-edgg
+.helpmm .msg $aircraft You can find pilot briefings for airports in FIR Munich at https://knowledgebase.vatsim-germany.org/books/airports-munchen-fir-edmm
+.helpww .msg $aircraft You can find pilot briefings for airports in FIR Bremen at https://knowledgebase.vatsim-germany.org/books/airports-bremen-fir-edww
+.helpxx .msg $aircraft You can find pilot briefings for uncontrolled airfields throughout Germany at https://knowledgebase.vatsim-germany.org/books/airfields-germany
+.helpkb .msg $aircraft You can find a lot of helpful information in the VATSIM Germany Knowledgebase (https://kb.vatger.de)
+.helpiata .msg $aircraft You seem to be logged in with the 2-letter IATA code for your airline. On VATSIM (and in the real world), we use the 3-letter ICAO codes. Please change your callsign accordingly and don't forget that you will have to refile your flight plan with the correct callsign as well. Otherwise, ATC might not recognize your callsign
+.helpequip .msg $aircraft You have not filed an equipment code (or have filed one that is most likely incorrect). Please keep in mind that filing a correct equipment code helps controllers to quickly see what type of procedures you are able to fly etc. You can learn more about equipment codes at https://www.faa.gov/sites/faa.gov/files/FAA%20FPL%20Quick%20Reference%20Brochure%20%282022-09-15%29.pdf
+.help833 .msg $aircraft You have been transferred to an 8.33kHz channel. If your simulator and/or aircraft does not support 8.33kHz channel spacing, you have to use ".com1 <frequency>" in your pilot client to tune to the correct frequency. You can learn more about the introduction of 8.33kHz channels to VATSIM at https://vats.im/833
+.helpxc .msg $aircraft Not all frequencies in use will show in the controller list of your pilot client, especially if a controller is using multiple frequencies. To ensure you can properly communicate with the correct controller, please always switch to the frequency given by ATC during the handoff
+.helpacdm .msg $aircraft If you are unfamiliar with the ACDM process, you can learn about it at https://knowledgebase.vatsim-germany.org/books/vacdm/page/vacdm-pilot-guide
+.helpfl .msg $aircraft Please make sure to correctly differentiate between flight level and altitude to ensure proper separation from terrain and other traffic. A flight level instruction (e.g. "climb to flight level 140") means that you have to use the STD QNH (1013.25hPa) as a barometric reference; an altitude instruction (e.g. "descend to 4000 feet") means that you have to use the local QNH.
 
 ;--- AUTOTEXT MESSAGES ---
 .autoproceed Proceed direct $uc($1)

--- a/alias.txt
+++ b/alias.txt
@@ -3,7 +3,7 @@
 .rpos report your position
 .co contact $radioname($1), $freq($1)
 .costby standby for $radioname($1), $freq($1)
-.coa revised airborne frequency is contact $radioname($1) on $freq($1)
+.coa revised airborne frequency is $radioname($1) on $freq($1)
 .uni monitor Unicom, 122.800
 .nma you are not in my airspace, switch back to Unicom, 122.800
 .wf wrong frequency, check again with the previous controller

--- a/alias.txt
+++ b/alias.txt
@@ -31,8 +31,8 @@
 .clrs startup approved. Cleared to $arr, $sid departure, flight planned route, climb to $temp, squawk $squawk
 .clrv cleared to $arr, $sid departure, flight planned route, climb via SID to $temp, squawk $squawk
 .clrvs startup approved. Cleared to $arr, $sid departure, flight planned route, climb via SID to $temp, squawk $squawk
-.clrvec cleared to $arr, after departure fly heading &1, vectors to $uc($2), flight planned route, climb to altitude $temp, squawk $squawk
-.clrvis cleared to $arr, visual departure, after departure fly heading &1, vectors to $uc($2), flight planned route maintain visual reference to the terrain until passing $uc($3) ft, climb to altitude $temp, squawk $squawk
+.clrvec cleared to $arr, after departure fly heading &1, vectors to $uc($2), flight planned route, climb to $temp, squawk $squawk
+.clrvis cleared to $arr, visual departure, after departure fly heading &1, vectors to $uc($2), flight planned route maintain visual reference to the terrain until passing $3 ft, climb to $temp, squawk $squawk
 .atis check information $uc($1)
 .rbr readback correct, report ready
 .su start-up approved


### PR DESCRIPTION
- added alias for revised airborne frequency (for airports without ATIS)
- added aliases for departure and arrival weather information (for airports without ATIS)
- removed altitude/flight level differentiation and combined aliases accordingly
- updated speed instructions in knots to be closer to correct voice phraseology (fly -> maintain)
- revised .helpfl alias to be closer to other help aliases in tone and style
- added option/requirement to add time of first contact me to .wallnoco to inform SUPs how long pilot has been unresponsive for already
- added ".msg $aircraft" in front of all aliases meant to be sent via private chat to remove the need for having to open a private chat before using the alias
- some smaller changes to align German and English aliases