### PR TITLE
Generalisierung .nma

### DIFF
--- a/alias.txt
+++ b/alias.txt
@@ -5,7 +5,7 @@
 .costby standby for $radioname($1), $freq($1)
 .coa revised airborne frequency is $radioname($1) on $freq($1)
 .adv monitor Advisory, 122.800
-.nma you are not in my airspace, switch back to Advisory, 122.800
+.nma I'm not expecting you, switch back to previous frequency
 .wf wrong frequency, check again with the previous controller
 .stby standby
 .rgr roger


### PR DESCRIPTION
Wie [hier](https://github.com/VATGER-Nav/aliases/pull/34#issuecomment-2444844170) von mir vorgeschlagen: Änderung des .nma Alias zur Möglichkeit der Verwendung in mehr Fällen. Mit der Änderung ist es nicht mehr nötig die Position des Flugzeuges zu überprüfen und sicherzustellen, dass kein Lotse für den Piloten zuständig ist bevor der Alias geschickt wird.